### PR TITLE
Add download-related stuffs to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -37,3 +37,5 @@ matplotlib
 pandas
 pillow
 nibabel
+kaggle
+gdown


### PR DESCRIPTION
As title, the requirements.txt missed some library needed for download things.
And they are also imported even with download=False so I think we should add them to req to prevent unexpected errors.